### PR TITLE
Run Tarpaulin under nightly toolchain for libmarlin coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,8 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
 
-      - name: Code coverage (libmarlin only)
-        run: cargo tarpaulin \
-               --package libmarlin \
-               --out Xml \
-               --fail-under 85
+      - name: Code Coverage (libmarlin only)
+        run: cargo +nightly tarpaulin --package libmarlin --out Xml --fail-under 85
 
   benchmark:
     name: Performance Benchmark (Hyperfine)


### PR DESCRIPTION
In our GitHub Actions CI, update the Code Coverage step for the `libmarlin` crate to invoke Tarpaulin using the nightly toolchain. This ensures we pick up the latest coverage features and avoid the unexpected argument error:

* Replace the two-line `cargo tarpaulin` invocation with a single command using `cargo +nightly tarpaulin --package libmarlin --out Xml --fail-under 85`.
* Removes the extraneous line break and aligns with the rest of our Rust commands under nightly when needed.