### PR TITLE
Add CLI run unit tests using in-memory DB

### DIFF
--- a/cli-bin/tests/cli_coll_unit.rs
+++ b/cli-bin/tests/cli_coll_unit.rs
@@ -1,0 +1,30 @@
+mod cli {
+    #[derive(Clone, Copy, Debug)]
+    pub enum Format { Text, Json }
+}
+
+#[path = "../src/cli/coll.rs"]
+mod coll;
+
+use libmarlin::db;
+
+#[test]
+fn coll_run_creates_and_adds() {
+    let mut conn = db::open(":memory:").unwrap();
+    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('a.txt',0,0)", []).unwrap();
+    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('b.txt',0,0)", []).unwrap();
+
+    let create = coll::CollCmd::Create(coll::CreateArgs{ name: "Set".into() });
+    coll::run(&create, &mut conn, cli::Format::Text).unwrap();
+
+    let coll_id: i64 = conn.query_row("SELECT id FROM collections WHERE name='Set'", [], |r| r.get(0)).unwrap();
+
+    let add = coll::CollCmd::Add(coll::AddArgs{ name: "Set".into(), file_pattern: "*.txt".into() });
+    coll::run(&add, &mut conn, cli::Format::Text).unwrap();
+
+    let cnt: i64 = conn.query_row("SELECT COUNT(*) FROM collection_files WHERE collection_id=?1", [coll_id], |r| r.get(0)).unwrap();
+    assert_eq!(cnt, 2);
+
+    let list = coll::CollCmd::List(coll::ListArgs{ name: "Set".into() });
+    coll::run(&list, &mut conn, cli::Format::Text).unwrap();
+}

--- a/cli-bin/tests/cli_link_unit.rs
+++ b/cli-bin/tests/cli_link_unit.rs
@@ -1,0 +1,37 @@
+mod cli {
+    #[derive(Clone, Copy, Debug)]
+    pub enum Format { Text, Json }
+}
+
+#[path = "../src/cli/link.rs"]
+mod link;
+
+use libmarlin::db;
+
+#[test]
+fn link_run_add_and_rm() {
+    let mut conn = db::open(":memory:").unwrap();
+    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('foo.txt',0,0)", []).unwrap();
+    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('bar.txt',0,0)", []).unwrap();
+
+    let add = link::LinkCmd::Add(link::LinkArgs {
+        from: "foo.txt".into(),
+        to:   "bar.txt".into(),
+        r#type: None,
+    });
+    link::run(&add, &mut conn, cli::Format::Text).unwrap();
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0)).unwrap();
+    assert_eq!(count, 1);
+
+    let list = link::LinkCmd::List(link::ListArgs { pattern: "foo.txt".into(), direction: None, r#type: None });
+    link::run(&list, &mut conn, cli::Format::Text).unwrap();
+
+    let rm = link::LinkCmd::Rm(link::LinkArgs {
+        from: "foo.txt".into(),
+        to:   "bar.txt".into(),
+        r#type: None,
+    });
+    link::run(&rm, &mut conn, cli::Format::Text).unwrap();
+    let remaining: i64 = conn.query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 0);
+}

--- a/cli-bin/tests/cli_view_unit.rs
+++ b/cli-bin/tests/cli_view_unit.rs
@@ -1,0 +1,27 @@
+mod cli {
+    #[derive(Clone, Copy, Debug)]
+    pub enum Format { Text, Json }
+}
+
+#[path = "../src/cli/view.rs"]
+mod view;
+
+use libmarlin::db;
+
+#[test]
+fn view_run_save_and_exec() {
+    let mut conn = db::open(":memory:").unwrap();
+    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('TODO.txt',0,0)", []).unwrap();
+
+    let save = view::ViewCmd::Save(view::ArgsSave { view_name: "tasks".into(), query: "TODO".into() });
+    view::run(&save, &mut conn, cli::Format::Text).unwrap();
+
+    let stored: String = conn.query_row("SELECT query FROM views WHERE name='tasks'", [], |r| r.get(0)).unwrap();
+    assert_eq!(stored, "TODO");
+
+    let list = view::ViewCmd::List;
+    view::run(&list, &mut conn, cli::Format::Text).unwrap();
+
+    let exec = view::ViewCmd::Exec(view::ArgsExec { view_name: "tasks".into() });
+    view::run(&exec, &mut conn, cli::Format::Text).unwrap();
+}


### PR DESCRIPTION
## Summary
- add unit tests for coll, link, and view `run` functions
- use `libmarlin::db::open(":memory:")` to create an in-memory DB for tests
- verify collections, links, and views operations update the database

## Testing
- `cargo test --quiet`