### PR TITLE
Add config fallback test

### DIFF
--- a/libmarlin/src/config.rs
+++ b/libmarlin/src/config.rs
@@ -35,12 +35,15 @@ impl Config {
         let digest = h.finish(); // 64-bit
         let file_name = format!("index_{digest:016x}.db");
 
-        if let Some(dirs) = ProjectDirs::from("io", "Marlin", "marlin") {
-            let dir = dirs.data_dir();
-            std::fs::create_dir_all(dir)?;
-            return Ok(Self {
-                db_path: dir.join(file_name),
-            });
+        // If HOME and XDG_DATA_HOME are missing we can't resolve an XDG path
+        if std::env::var_os("HOME").is_some() || std::env::var_os("XDG_DATA_HOME").is_some() {
+            if let Some(dirs) = ProjectDirs::from("io", "Marlin", "marlin") {
+                let dir = dirs.data_dir();
+                std::fs::create_dir_all(dir)?;
+                return Ok(Self {
+                    db_path: dir.join(file_name),
+                });
+            }
         }
 
         // 3) very last resort – workspace-relative DB

--- a/libmarlin/src/config_tests.rs
+++ b/libmarlin/src/config_tests.rs
@@ -20,3 +20,42 @@ fn load_xdg_or_fallback() {
     let cfg = Config::load().unwrap();
     assert!(cfg.db_path.to_string_lossy().ends_with(".db"));
 }
+
+#[test]
+fn load_fallback_current_dir() {
+    // Save and clear HOME & XDG_DATA_HOME
+    let orig_home = env::var_os("HOME");
+    let orig_xdg = env::var_os("XDG_DATA_HOME");
+    env::remove_var("HOME");
+    env::remove_var("XDG_DATA_HOME");
+    env::remove_var("MARLIN_DB_PATH");
+
+    let cfg = Config::load().unwrap();
+
+    // Compute expected file name based on current directory hash
+    let cwd = env::current_dir().unwrap();
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    cwd.hash(&mut h);
+    let digest = h.finish();
+    let expected_name = format!("index_{:016x}.db", digest);
+
+    assert_eq!(cfg.db_path, std::path::PathBuf::from(&expected_name));
+    assert!(cfg
+        .db_path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with("index_"));
+
+    // Restore environment variables
+    match orig_home {
+        Some(val) => env::set_var("HOME", val),
+        None => env::remove_var("HOME"),
+    }
+    match orig_xdg {
+        Some(val) => env::set_var("XDG_DATA_HOME", val),
+        None => env::remove_var("XDG_DATA_HOME"),
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Config::load` to skip XDG dirs when both `HOME` and `XDG_DATA_HOME` are absent
- add new unit test verifying fallback behaviour when no HOME or XDG variables

## Testing
- `cargo test --lib config_tests::load_fallback_current_dir -- --exact --nocapture`
- `cargo test`