### PR TITLE
Handle mutex poisoning in watcher

### DIFF
--- a/cli-bin/src/cli/watch.rs
+++ b/cli-bin/src/cli/watch.rs
@@ -56,8 +56,8 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
             info!("Starting watcher for directory: {}", canon_path.display());
 
             let mut watcher = marlin.watch(&canon_path, Some(config))?;
-            
-            let status = watcher.status();
+
+            let status = watcher.status()?;
             info!("Watcher started. Press Ctrl+C to stop watching.");
             info!("Watching {} paths", status.watched_paths.len());
             
@@ -73,7 +73,7 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
 
             info!("Watcher run loop started. Waiting for Ctrl+C or stop signal...");
             while running.load(Ordering::SeqCst) {
-                let current_status = watcher.status();
+                let current_status = watcher.status()?;
                 if current_status.state == WatcherState::Stopped {
                     info!("Watcher has stopped (detected by state). Exiting loop.");
                     break;
@@ -98,7 +98,7 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
             watcher.stop()?;
             {
                 let mut guard = LAST_WATCHER_STATE.lock().unwrap();
-                *guard = Some(watcher.status().state);
+                *guard = Some(watcher.status()?.state);
             }
             info!("Watcher instance fully stopped.");
             Ok(())

--- a/cli-bin/tests/integration/watcher/watcher_test.rs
+++ b/cli-bin/tests/integration/watcher/watcher_test.rs
@@ -129,7 +129,7 @@ fn test_basic_watch_functionality() {
     let finished_watcher = watcher_thread.join().expect("Watcher thread panicked");
     
     // Check status after processing events
-    let status = finished_watcher.status();
+    let status = finished_watcher.status().unwrap();
     
     // Assertions
     assert_eq!(status.state, WatcherState::Stopped);
@@ -190,7 +190,7 @@ fn test_debouncing() {
     
     // Complete the test
     let finished_watcher = watcher_thread.join().expect("Watcher thread panicked");
-    let status = finished_watcher.status();
+    let status = finished_watcher.status().unwrap();
     
     // We should have processed fewer events than modifications made
     // due to debouncing (exact count depends on implementation details)
@@ -248,7 +248,7 @@ fn test_event_flood() {
     
     // Complete the test
     let finished_watcher = watcher_thread.join().expect("Watcher thread panicked");
-    let status = finished_watcher.status();
+    let status = finished_watcher.status().unwrap();
     
     // Verify processing occurred
     assert!(status.events_processed > 0, "Expected events to be processed");
@@ -355,7 +355,7 @@ fn test_graceful_shutdown() {
             "Shutdown took too long");
     
     // Verify final state
-    let status = watcher.status();
+    let status = watcher.status().unwrap();
     assert_eq!(status.state, WatcherState::Stopped);
     assert_eq!(status.queue_size, 0, "Queue should be empty after shutdown");
     

--- a/libmarlin/src/lib.rs
+++ b/libmarlin/src/lib.rs
@@ -199,7 +199,7 @@ impl Marlin {
         let watcher_db = Arc::new(Mutex::new(db::Database::new(new_conn)));
         
         let mut owned_w = watcher::FileWatcher::new(vec![p], cfg)?;
-        owned_w.with_database(watcher_db); // Modifies owned_w in place
+        owned_w.with_database(watcher_db)?; // Modifies owned_w in place
         owned_w.start()?; // Start the watcher after it has been fully configured
         
         Ok(owned_w) // Return the owned FileWatcher

--- a/libmarlin/src/watcher_tests.rs
+++ b/libmarlin/src/watcher_tests.rs
@@ -40,7 +40,7 @@ mod tests {
             .expect("Failed to create watcher");
 
         watcher.start().expect("Failed to start watcher");
-        assert_eq!(watcher.status().state, WatcherState::Watching);
+        assert_eq!(watcher.status().unwrap().state, WatcherState::Watching);
 
         thread::sleep(Duration::from_millis(200));
         let new_file_path = temp_path.join("new_file.txt");
@@ -63,8 +63,8 @@ mod tests {
         thread::sleep(Duration::from_millis(500));
         watcher.stop().expect("Failed to stop watcher");
 
-        assert_eq!(watcher.status().state, WatcherState::Stopped);
-        assert!(watcher.status().events_processed > 0, "Expected some file events to be processed");
+        assert_eq!(watcher.status().unwrap().state, WatcherState::Stopped);
+        assert!(watcher.status().unwrap().events_processed > 0, "Expected some file events to be processed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- guard mutex access in `FileWatcher` with `map_err` instead of `unwrap`
- return `Result` from `with_database` and `status`
- update CLI and tests for new `Result` APIs
- add tests covering poisoned mutex behaviour

## Testing
- `cargo test --quiet`