### PR TITLE
Format codebase with rustfmt

### DIFF
--- a/cli-bin/build.rs
+++ b/cli-bin/build.rs
@@ -28,7 +28,9 @@ fn generate_cheatsheet() -> Result<(), Box<dyn std::error::Error>> {
         for (cmd_name_val, cmd_details_val) in cmds {
             let cmd_name = cmd_name_val.as_str().unwrap_or("");
             if let Value::Mapping(cmd_details) = cmd_details_val {
-                if let Some(Value::Mapping(actions)) = cmd_details.get(&Value::String("actions".into())) {
+                if let Some(Value::Mapping(actions)) =
+                    cmd_details.get(&Value::String("actions".into()))
+                {
                     for (action_name_val, action_body_val) in actions {
                         let action_name = action_name_val.as_str().unwrap_or("");
                         let flags = if let Value::Mapping(action_map) = action_body_val {
@@ -45,7 +47,11 @@ fn generate_cheatsheet() -> Result<(), Box<dyn std::error::Error>> {
                         };
 
                         let flags_disp = if flags.is_empty() { "—" } else { &flags };
-                        table.push_str(&format!("| `{}` | {} |\n", format!("{} {}", cmd_name, action_name), flags_disp));
+                        table.push_str(&format!(
+                            "| `{}` | {} |\n",
+                            format!("{} {}", cmd_name, action_name),
+                            flags_disp
+                        ));
                     }
                 }
             }

--- a/cli-bin/src/cli.rs
+++ b/cli-bin/src/cli.rs
@@ -1,14 +1,14 @@
 // src/cli.rs
 
-pub mod link;
+pub mod annotate;
 pub mod coll;
-pub mod view;
+pub mod event;
+pub mod link;
+pub mod remind;
 pub mod state;
 pub mod task;
-pub mod remind;
-pub mod annotate;
 pub mod version;
-pub mod event;
+pub mod view;
 pub mod watch;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -77,9 +77,7 @@ pub enum Commands {
     Backup,
 
     /// Restore from a backup file (overwrites current DB)
-    Restore {
-        backup_path: std::path::PathBuf,
-    },
+    Restore { backup_path: std::path::PathBuf },
 
     /// Generate shell completions (hidden)
     #[command(hide = true)]
@@ -132,6 +130,12 @@ pub enum Commands {
 
 #[derive(Subcommand, Debug)]
 pub enum AttrCmd {
-    Set { pattern: String, key: String, value: String },
-    Ls  { path: std::path::PathBuf },
+    Set {
+        pattern: String,
+        key: String,
+        value: String,
+    },
+    Ls {
+        path: std::path::PathBuf,
+    },
 }

--- a/cli-bin/src/cli/annotate.rs
+++ b/cli-bin/src/cli/annotate.rs
@@ -1,11 +1,11 @@
 // src/cli/annotate.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum AnnotateCmd {
-    Add (ArgsAdd),
+    Add(ArgsAdd),
     List(ArgsList),
 }
 
@@ -13,16 +13,20 @@ pub enum AnnotateCmd {
 pub struct ArgsAdd {
     pub file: String,
     pub note: String,
-    #[arg(long)] pub range: Option<String>,
-    #[arg(long)] pub highlight: bool,
+    #[arg(long)]
+    pub range: Option<String>,
+    #[arg(long)]
+    pub highlight: bool,
 }
 
 #[derive(Args, Debug)]
-pub struct ArgsList { pub file_pattern: String }
+pub struct ArgsList {
+    pub file_pattern: String,
+}
 
 pub fn run(cmd: &AnnotateCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {
     match cmd {
-        AnnotateCmd::Add(a)  => todo!("annotate add {:?}", a),
+        AnnotateCmd::Add(a) => todo!("annotate add {:?}", a),
         AnnotateCmd::List(a) => todo!("annotate list {:?}", a),
     }
 }

--- a/cli-bin/src/cli/coll.rs
+++ b/cli-bin/src/cli/coll.rs
@@ -3,8 +3,8 @@
 use clap::{Args, Subcommand};
 use rusqlite::Connection;
 
-use crate::cli::Format;   // local enum for text / json output
-use libmarlin::db;        // core DB helpers from the library crate
+use crate::cli::Format; // local enum for text / json output
+use libmarlin::db; // core DB helpers from the library crate
 
 #[derive(Subcommand, Debug)]
 pub enum CollCmd {
@@ -36,11 +36,9 @@ pub struct ListArgs {
 ///
 /// Returns the collection ID or an error if it doesn’t exist.
 fn lookup_collection_id(conn: &Connection, name: &str) -> anyhow::Result<i64> {
-    conn.query_row(
-        "SELECT id FROM collections WHERE name = ?1",
-        [name],
-        |r| r.get(0),
-    )
+    conn.query_row("SELECT id FROM collections WHERE name = ?1", [name], |r| {
+        r.get(0)
+    })
     .map_err(|_| anyhow::anyhow!("collection not found: {}", name))
 }
 
@@ -74,11 +72,7 @@ pub fn run(cmd: &CollCmd, conn: &mut Connection, fmt: Format) -> anyhow::Result<
                 Format::Json => {
                     #[cfg(feature = "json")]
                     {
-                        println!(
-                            "{{\"collection\":\"{}\",\"added\":{}}}",
-                            a.name,
-                            ids.len()
-                        );
+                        println!("{{\"collection\":\"{}\",\"added\":{}}}", a.name, ids.len());
                     }
                 }
             }

--- a/cli-bin/src/cli/event.rs
+++ b/cli-bin/src/cli/event.rs
@@ -1,11 +1,11 @@
 // src/cli/event.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum EventCmd {
-    Add     (ArgsAdd),
+    Add(ArgsAdd),
     Timeline,
 }
 
@@ -18,7 +18,7 @@ pub struct ArgsAdd {
 
 pub fn run(cmd: &EventCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {
     match cmd {
-        EventCmd::Add(a)      => todo!("event add {:?}", a),
-        EventCmd::Timeline    => todo!("event timeline"),
+        EventCmd::Add(a) => todo!("event add {:?}", a),
+        EventCmd::Timeline => todo!("event timeline"),
     }
 }

--- a/cli-bin/src/cli/link.rs
+++ b/cli-bin/src/cli/link.rs
@@ -1,15 +1,15 @@
 //! src/cli/link.rs – manage typed relationships between files
 
-use clap::{Subcommand, Args};
+use clap::{Args, Subcommand};
 use rusqlite::Connection;
 
-use crate::cli::Format;   // output selector
-use libmarlin::db;        // ← switched from `crate::db`
+use crate::cli::Format; // output selector
+use libmarlin::db; // ← switched from `crate::db`
 
 #[derive(Subcommand, Debug)]
 pub enum LinkCmd {
     Add(LinkArgs),
-    Rm (LinkArgs),
+    Rm(LinkArgs),
     List(ListArgs),
     Backlinks(BacklinksArgs),
 }
@@ -17,7 +17,7 @@ pub enum LinkCmd {
 #[derive(Args, Debug)]
 pub struct LinkArgs {
     pub from: String,
-    pub to:   String,
+    pub to: String,
     #[arg(long)]
     pub r#type: Option<String>,
 }
@@ -70,7 +70,10 @@ pub fn run(cmd: &LinkCmd, conn: &mut Connection, format: Format) -> anyhow::Resu
             match format {
                 Format::Text => {
                     if let Some(t) = &args.r#type {
-                        println!("Removed link '{}' → '{}' [type='{}']", args.from, args.to, t);
+                        println!(
+                            "Removed link '{}' → '{}' [type='{}']",
+                            args.from, args.to, t
+                        );
                     } else {
                         println!("Removed link '{}' → '{}'", args.from, args.to);
                     }

--- a/cli-bin/src/cli/remind.rs
+++ b/cli-bin/src/cli/remind.rs
@@ -1,7 +1,7 @@
 // src/cli/remind.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum RemindCmd {
@@ -11,8 +11,8 @@ pub enum RemindCmd {
 #[derive(Args, Debug)]
 pub struct ArgsSet {
     pub file_pattern: String,
-    pub timestamp:    String,
-    pub message:      String,
+    pub timestamp: String,
+    pub message: String,
 }
 
 pub fn run(cmd: &RemindCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {

--- a/cli-bin/src/cli/state.rs
+++ b/cli-bin/src/cli/state.rs
@@ -1,7 +1,7 @@
 // src/cli/state.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum StateCmd {
@@ -11,16 +11,24 @@ pub enum StateCmd {
 }
 
 #[derive(Args, Debug)]
-pub struct ArgsSet   { pub file_pattern: String, pub new_state: String }
+pub struct ArgsSet {
+    pub file_pattern: String,
+    pub new_state: String,
+}
 #[derive(Args, Debug)]
-pub struct ArgsTrans { pub from_state: String,   pub to_state: String }
+pub struct ArgsTrans {
+    pub from_state: String,
+    pub to_state: String,
+}
 #[derive(Args, Debug)]
-pub struct ArgsLog   { pub file_pattern: String }
+pub struct ArgsLog {
+    pub file_pattern: String,
+}
 
 pub fn run(cmd: &StateCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {
     match cmd {
-        StateCmd::Set(a)           => todo!("state set {:?}", a),
-        StateCmd::TransitionsAdd(a)=> todo!("state transitions-add {:?}", a),
-        StateCmd::Log(a)           => todo!("state log {:?}", a),
+        StateCmd::Set(a) => todo!("state set {:?}", a),
+        StateCmd::TransitionsAdd(a) => todo!("state transitions-add {:?}", a),
+        StateCmd::Log(a) => todo!("state log {:?}", a),
     }
 }

--- a/cli-bin/src/cli/task.rs
+++ b/cli-bin/src/cli/task.rs
@@ -1,7 +1,7 @@
 // src/cli/task.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum TaskCmd {
@@ -10,9 +10,14 @@ pub enum TaskCmd {
 }
 
 #[derive(Args, Debug)]
-pub struct ArgsScan { pub directory: String }
+pub struct ArgsScan {
+    pub directory: String,
+}
 #[derive(Args, Debug)]
-pub struct ArgsList { #[arg(long)] pub due_today: bool }
+pub struct ArgsList {
+    #[arg(long)]
+    pub due_today: bool,
+}
 
 pub fn run(cmd: &TaskCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {
     match cmd {

--- a/cli-bin/src/cli/version.rs
+++ b/cli-bin/src/cli/version.rs
@@ -1,7 +1,7 @@
 // src/cli/version.rs
-use clap::{Subcommand, Args};
-use rusqlite::Connection;
 use crate::cli::Format;
+use clap::{Args, Subcommand};
+use rusqlite::Connection;
 
 #[derive(Subcommand, Debug)]
 pub enum VersionCmd {
@@ -9,7 +9,9 @@ pub enum VersionCmd {
 }
 
 #[derive(Args, Debug)]
-pub struct ArgsDiff { pub file: String }
+pub struct ArgsDiff {
+    pub file: String,
+}
 
 pub fn run(cmd: &VersionCmd, _conn: &mut Connection, _format: Format) -> anyhow::Result<()> {
     match cmd {

--- a/cli-bin/src/cli/view.rs
+++ b/cli-bin/src/cli/view.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use rusqlite::Connection;
 
-use crate::cli::Format;   // output selector stays local
-use libmarlin::db;        // ← path switched from `crate::db`
+use crate::cli::Format; // output selector stays local
+use libmarlin::db; // ← path switched from `crate::db`
 
 #[derive(Subcommand, Debug)]
 pub enum ViewCmd {

--- a/cli-bin/src/cli/watch.rs
+++ b/cli-bin/src/cli/watch.rs
@@ -5,8 +5,8 @@ use clap::Subcommand;
 use libmarlin::watcher::{WatcherConfig, WatcherState};
 use rusqlite::Connection;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use tracing::info;
@@ -30,15 +30,15 @@ pub enum WatchCmd {
         /// Directory to watch (defaults to current directory)
         #[arg(default_value = ".")]
         path: PathBuf,
-        
+
         /// Debounce window in milliseconds (default: 100ms)
         #[arg(long, default_value = "100")]
         debounce_ms: u64,
     },
-    
+
     /// Show status of currently active watcher
     Status,
-    
+
     /// Stop the currently running watcher
     Stop,
 }
@@ -60,7 +60,7 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
             let status = watcher.status()?;
             info!("Watcher started. Press Ctrl+C to stop watching.");
             info!("Watching {} paths", status.watched_paths.len());
-            
+
             let start_time = Instant::now();
             let mut last_status_time = Instant::now();
             let running = Arc::new(AtomicBool::new(true));
@@ -80,7 +80,7 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
                 }
 
                 // Corrected line: removed the extra closing parenthesis
-                if last_status_time.elapsed() > Duration::from_secs(10) { 
+                if last_status_time.elapsed() > Duration::from_secs(10) {
                     let uptime = start_time.elapsed();
                     info!(
                         "Watcher running for {}s, processed {} events, queue: {}, state: {:?}",
@@ -104,7 +104,9 @@ pub fn run(cmd: &WatchCmd, _conn: &mut Connection, _format: super::Format) -> Re
             Ok(())
         }
         WatchCmd::Status => {
-            info!("Status command: No active watcher process to query in this CLI invocation model.");
+            info!(
+                "Status command: No active watcher process to query in this CLI invocation model."
+            );
             info!("To see live status, run 'marlin watch start' which prints periodic updates.");
             Ok(())
         }

--- a/cli-bin/tests/cli_coll_unit.rs
+++ b/cli-bin/tests/cli_coll_unit.rs
@@ -1,6 +1,9 @@
 mod cli {
     #[derive(Clone, Copy, Debug)]
-    pub enum Format { Text, Json }
+    pub enum Format {
+        Text,
+        Json,
+    }
 }
 
 #[path = "../src/cli/coll.rs"]
@@ -11,20 +14,41 @@ use libmarlin::db;
 #[test]
 fn coll_run_creates_and_adds() {
     let mut conn = db::open(":memory:").unwrap();
-    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('a.txt',0,0)", []).unwrap();
-    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('b.txt',0,0)", []).unwrap();
+    conn.execute(
+        "INSERT INTO files(path,size,mtime) VALUES ('a.txt',0,0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO files(path,size,mtime) VALUES ('b.txt',0,0)",
+        [],
+    )
+    .unwrap();
 
-    let create = coll::CollCmd::Create(coll::CreateArgs{ name: "Set".into() });
+    let create = coll::CollCmd::Create(coll::CreateArgs { name: "Set".into() });
     coll::run(&create, &mut conn, cli::Format::Text).unwrap();
 
-    let coll_id: i64 = conn.query_row("SELECT id FROM collections WHERE name='Set'", [], |r| r.get(0)).unwrap();
+    let coll_id: i64 = conn
+        .query_row("SELECT id FROM collections WHERE name='Set'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
 
-    let add = coll::CollCmd::Add(coll::AddArgs{ name: "Set".into(), file_pattern: "*.txt".into() });
+    let add = coll::CollCmd::Add(coll::AddArgs {
+        name: "Set".into(),
+        file_pattern: "*.txt".into(),
+    });
     coll::run(&add, &mut conn, cli::Format::Text).unwrap();
 
-    let cnt: i64 = conn.query_row("SELECT COUNT(*) FROM collection_files WHERE collection_id=?1", [coll_id], |r| r.get(0)).unwrap();
+    let cnt: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM collection_files WHERE collection_id=?1",
+            [coll_id],
+            |r| r.get(0),
+        )
+        .unwrap();
     assert_eq!(cnt, 2);
 
-    let list = coll::CollCmd::List(coll::ListArgs{ name: "Set".into() });
+    let list = coll::CollCmd::List(coll::ListArgs { name: "Set".into() });
     coll::run(&list, &mut conn, cli::Format::Text).unwrap();
 }

--- a/cli-bin/tests/cli_link_unit.rs
+++ b/cli-bin/tests/cli_link_unit.rs
@@ -1,6 +1,9 @@
 mod cli {
     #[derive(Clone, Copy, Debug)]
-    pub enum Format { Text, Json }
+    pub enum Format {
+        Text,
+        Json,
+    }
 }
 
 #[path = "../src/cli/link.rs"]
@@ -11,27 +14,43 @@ use libmarlin::db;
 #[test]
 fn link_run_add_and_rm() {
     let mut conn = db::open(":memory:").unwrap();
-    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('foo.txt',0,0)", []).unwrap();
-    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('bar.txt',0,0)", []).unwrap();
+    conn.execute(
+        "INSERT INTO files(path,size,mtime) VALUES ('foo.txt',0,0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO files(path,size,mtime) VALUES ('bar.txt',0,0)",
+        [],
+    )
+    .unwrap();
 
     let add = link::LinkCmd::Add(link::LinkArgs {
         from: "foo.txt".into(),
-        to:   "bar.txt".into(),
+        to: "bar.txt".into(),
         r#type: None,
     });
     link::run(&add, &mut conn, cli::Format::Text).unwrap();
-    let count: i64 = conn.query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0)).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0))
+        .unwrap();
     assert_eq!(count, 1);
 
-    let list = link::LinkCmd::List(link::ListArgs { pattern: "foo.txt".into(), direction: None, r#type: None });
+    let list = link::LinkCmd::List(link::ListArgs {
+        pattern: "foo.txt".into(),
+        direction: None,
+        r#type: None,
+    });
     link::run(&list, &mut conn, cli::Format::Text).unwrap();
 
     let rm = link::LinkCmd::Rm(link::LinkArgs {
         from: "foo.txt".into(),
-        to:   "bar.txt".into(),
+        to: "bar.txt".into(),
         r#type: None,
     });
     link::run(&rm, &mut conn, cli::Format::Text).unwrap();
-    let remaining: i64 = conn.query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0)).unwrap();
+    let remaining: i64 = conn
+        .query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0))
+        .unwrap();
     assert_eq!(remaining, 0);
 }

--- a/cli-bin/tests/cli_view_unit.rs
+++ b/cli-bin/tests/cli_view_unit.rs
@@ -1,6 +1,9 @@
 mod cli {
     #[derive(Clone, Copy, Debug)]
-    pub enum Format { Text, Json }
+    pub enum Format {
+        Text,
+        Json,
+    }
 }
 
 #[path = "../src/cli/view.rs"]
@@ -11,17 +14,30 @@ use libmarlin::db;
 #[test]
 fn view_run_save_and_exec() {
     let mut conn = db::open(":memory:").unwrap();
-    conn.execute("INSERT INTO files(path,size,mtime) VALUES ('TODO.txt',0,0)", []).unwrap();
+    conn.execute(
+        "INSERT INTO files(path,size,mtime) VALUES ('TODO.txt',0,0)",
+        [],
+    )
+    .unwrap();
 
-    let save = view::ViewCmd::Save(view::ArgsSave { view_name: "tasks".into(), query: "TODO".into() });
+    let save = view::ViewCmd::Save(view::ArgsSave {
+        view_name: "tasks".into(),
+        query: "TODO".into(),
+    });
     view::run(&save, &mut conn, cli::Format::Text).unwrap();
 
-    let stored: String = conn.query_row("SELECT query FROM views WHERE name='tasks'", [], |r| r.get(0)).unwrap();
+    let stored: String = conn
+        .query_row("SELECT query FROM views WHERE name='tasks'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
     assert_eq!(stored, "TODO");
 
     let list = view::ViewCmd::List;
     view::run(&list, &mut conn, cli::Format::Text).unwrap();
 
-    let exec = view::ViewCmd::Exec(view::ArgsExec { view_name: "tasks".into() });
+    let exec = view::ViewCmd::Exec(view::ArgsExec {
+        view_name: "tasks".into(),
+    });
     view::run(&exec, &mut conn, cli::Format::Text).unwrap();
 }

--- a/cli-bin/tests/e2e.rs
+++ b/cli-bin/tests/e2e.rs
@@ -25,8 +25,8 @@ fn spawn_demo_tree(root: &PathBuf) {
     fs::write(root.join("Projects/Alpha/draft2.md"), "- [x] TODO foo\n").unwrap();
     fs::write(root.join("Projects/Beta/final.md"), "done\n").unwrap();
     fs::write(root.join("Projects/Gamma/TODO.txt"), "TODO bar\n").unwrap();
-    fs::write(root.join("Logs/app.log"),           "ERROR omg\n").unwrap();
-    fs::write(root.join("Reports/Q1.pdf"),         "PDF\n").unwrap();
+    fs::write(root.join("Logs/app.log"), "ERROR omg\n").unwrap();
+    fs::write(root.join("Reports/Q1.pdf"), "PDF\n").unwrap();
 }
 
 /// Shorthand for “run and must succeed”.
@@ -38,7 +38,7 @@ fn ok(cmd: &mut Command) -> assert_cmd::assert::Assert {
 fn full_cli_flow() -> Result<(), Box<dyn std::error::Error>> {
     /* ── 1 ░ sandbox ───────────────────────────────────────────── */
 
-    let tmp      = tempdir()?;                 // wiped on drop
+    let tmp = tempdir()?; // wiped on drop
     let demo_dir = tmp.path().join("marlin_demo");
     spawn_demo_tree(&demo_dir);
 
@@ -53,9 +53,7 @@ fn full_cli_flow() -> Result<(), Box<dyn std::error::Error>> {
 
     /* ── 2 ░ init ( auto-scan cwd ) ───────────────────────────── */
 
-    ok(marlin()
-        .current_dir(&demo_dir)
-        .arg("init"));
+    ok(marlin().current_dir(&demo_dir).arg("init"));
 
     /* ── 3 ░ tag & attr demos ─────────────────────────────────── */
 
@@ -74,12 +72,14 @@ fn full_cli_flow() -> Result<(), Box<dyn std::error::Error>> {
     /* ── 4 ░ quick search sanity checks ───────────────────────── */
 
     marlin()
-        .arg("search").arg("TODO")
+        .arg("search")
+        .arg("TODO")
         .assert()
         .stdout(predicate::str::contains("TODO.txt"));
 
     marlin()
-        .arg("search").arg("attr:reviewed=yes")
+        .arg("search")
+        .arg("attr:reviewed=yes")
         .assert()
         .stdout(predicate::str::contains("Q1.pdf"));
 
@@ -92,31 +92,29 @@ fn full_cli_flow() -> Result<(), Box<dyn std::error::Error>> {
 
     ok(marlin().arg("scan").arg(&demo_dir));
 
-    ok(marlin()
-        .arg("link").arg("add")
-        .arg(&foo).arg(&bar));
+    ok(marlin().arg("link").arg("add").arg(&foo).arg(&bar));
 
     marlin()
-        .arg("link").arg("backlinks").arg(&bar)
+        .arg("link")
+        .arg("backlinks")
+        .arg(&bar)
         .assert()
         .stdout(predicate::str::contains("foo.txt"));
 
     /* ── 6 ░ backup → delete DB → restore ────────────────────── */
 
-    let backup_path = String::from_utf8(
-        marlin().arg("backup").output()?.stdout
-    )?;
+    let backup_path = String::from_utf8(marlin().arg("backup").output()?.stdout)?;
     let backup_file = backup_path.split_whitespace().last().unwrap();
 
-    fs::remove_file(&db_path)?;                        // simulate corruption
-    ok(marlin().arg("restore").arg(backup_file));      // restore
+    fs::remove_file(&db_path)?; // simulate corruption
+    ok(marlin().arg("restore").arg(backup_file)); // restore
 
     // Search must still work afterwards
     marlin()
-        .arg("search").arg("TODO")
+        .arg("search")
+        .arg("TODO")
         .assert()
         .stdout(predicate::str::contains("TODO.txt"));
 
     Ok(())
 }
-

--- a/cli-bin/tests/neg.rs
+++ b/cli-bin/tests/neg.rs
@@ -13,7 +13,11 @@ use util::marlin;
 fn link_non_indexed_should_fail() {
     let tmp = tempdir().unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     std::fs::write(tmp.path().join("foo.txt"), "").unwrap();
     std::fs::write(tmp.path().join("bar.txt"), "").unwrap();
@@ -21,9 +25,10 @@ fn link_non_indexed_should_fail() {
     marlin(&tmp)
         .current_dir(tmp.path())
         .args([
-            "link", "add",
+            "link",
+            "add",
             &tmp.path().join("foo.txt").to_string_lossy(),
-            &tmp.path().join("bar.txt").to_string_lossy()
+            &tmp.path().join("bar.txt").to_string_lossy(),
         ])
         .assert()
         .failure()
@@ -35,16 +40,19 @@ fn link_non_indexed_should_fail() {
 #[test]
 fn attr_set_on_non_indexed_file_should_warn() {
     let tmp = tempdir().unwrap();
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     let ghost = tmp.path().join("ghost.txt");
     std::fs::write(&ghost, "").unwrap();
 
     marlin(&tmp)
-        .args(["attr","set",
-               &ghost.to_string_lossy(),"foo","bar"])
+        .args(["attr", "set", &ghost.to_string_lossy(), "foo", "bar"])
         .assert()
-        .success()                       // exits 0
+        .success() // exits 0
         .stderr(str::contains("not indexed"));
 }
 
@@ -52,14 +60,18 @@ fn attr_set_on_non_indexed_file_should_warn() {
 
 #[test]
 fn coll_add_unknown_collection_should_fail() {
-    let tmp  = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
     let file = tmp.path().join("doc.txt");
     std::fs::write(&file, "").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     marlin(&tmp)
-        .args(["coll","add","nope",&file.to_string_lossy()])
+        .args(["coll", "add", "nope", &file.to_string_lossy()])
         .assert()
         .failure();
 }
@@ -68,7 +80,7 @@ fn coll_add_unknown_collection_should_fail() {
 
 #[test]
 fn restore_with_nonexistent_backup_should_fail() {
-    let tmp   = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
 
     // create an empty DB first
     marlin(&tmp).arg("init").assert().success();
@@ -79,4 +91,3 @@ fn restore_with_nonexistent_backup_should_fail() {
         .failure()
         .stderr(str::contains("Failed to restore"));
 }
-

--- a/cli-bin/tests/pos.rs
+++ b/cli-bin/tests/pos.rs
@@ -5,7 +5,7 @@
 mod util;
 use util::marlin;
 
-use predicates::{prelude::*, str};          // brings `PredicateBooleanExt::and`
+use predicates::{prelude::*, str}; // brings `PredicateBooleanExt::and`
 use std::fs;
 use tempfile::tempdir;
 
@@ -13,15 +13,20 @@ use tempfile::tempdir;
 
 #[test]
 fn tag_should_add_hierarchical_tag_and_search_finds_it() {
-    let tmp  = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
     let file = tmp.path().join("foo.md");
     fs::write(&file, "# test\n").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     marlin(&tmp)
         .args(["tag", file.to_str().unwrap(), "project/md"])
-        .assert().success();
+        .assert()
+        .success();
 
     marlin(&tmp)
         .args(["search", "tag:project/md"])
@@ -34,15 +39,20 @@ fn tag_should_add_hierarchical_tag_and_search_finds_it() {
 
 #[test]
 fn attr_set_then_ls_roundtrip() {
-    let tmp  = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
     let file = tmp.path().join("report.pdf");
     fs::write(&file, "%PDF-1.4\n").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     marlin(&tmp)
         .args(["attr", "set", file.to_str().unwrap(), "reviewed", "yes"])
-        .assert().success();
+        .assert()
+        .success();
 
     marlin(&tmp)
         .args(["attr", "ls", file.to_str().unwrap()])
@@ -62,11 +72,21 @@ fn coll_create_add_and_list() {
     fs::write(&a, "").unwrap();
     fs::write(&b, "").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
-    marlin(&tmp).args(["coll", "create", "Set"]).assert().success();
+    marlin(&tmp)
+        .args(["coll", "create", "Set"])
+        .assert()
+        .success();
     for f in [&a, &b] {
-        marlin(&tmp).args(["coll", "add", "Set", f.to_str().unwrap()]).assert().success();
+        marlin(&tmp)
+            .args(["coll", "add", "Set", f.to_str().unwrap()])
+            .assert()
+            .success();
     }
 
     marlin(&tmp)
@@ -80,15 +100,22 @@ fn coll_create_add_and_list() {
 
 #[test]
 fn view_save_list_and_exec() {
-    let tmp  = tempdir().unwrap();
+    let tmp = tempdir().unwrap();
 
     let todo = tmp.path().join("TODO.txt");
     fs::write(&todo, "remember the milk\n").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     // save & list
-    marlin(&tmp).args(["view", "save", "tasks", "milk"]).assert().success();
+    marlin(&tmp)
+        .args(["view", "save", "tasks", "milk"])
+        .assert()
+        .success();
     marlin(&tmp)
         .args(["view", "list"])
         .assert()
@@ -118,24 +145,30 @@ fn link_add_rm_and_list() {
     let mc = || marlin(&tmp);
 
     mc().current_dir(tmp.path()).arg("init").assert().success();
-    mc().args(["scan", tmp.path().to_str().unwrap()]).assert().success();
+    mc().args(["scan", tmp.path().to_str().unwrap()])
+        .assert()
+        .success();
 
     // add
     mc().args(["link", "add", foo.to_str().unwrap(), bar.to_str().unwrap()])
-        .assert().success();
+        .assert()
+        .success();
 
     // list (outgoing default)
     mc().args(["link", "list", foo.to_str().unwrap()])
-        .assert().success()
+        .assert()
+        .success()
         .stdout(str::contains("foo.txt").and(str::contains("bar.txt")));
 
     // remove
     mc().args(["link", "rm", foo.to_str().unwrap(), bar.to_str().unwrap()])
-        .assert().success();
+        .assert()
+        .success();
 
     // list now empty
     mc().args(["link", "list", foo.to_str().unwrap()])
-        .assert().success()
+        .assert()
+        .success()
         .stdout(str::is_empty());
 }
 
@@ -154,19 +187,24 @@ fn scan_with_multiple_paths_indexes_all() {
     fs::write(&f1, "").unwrap();
     fs::write(&f2, "").unwrap();
 
-    marlin(&tmp).current_dir(tmp.path()).arg("init").assert().success();
+    marlin(&tmp)
+        .current_dir(tmp.path())
+        .arg("init")
+        .assert()
+        .success();
 
     // multi-path scan
     marlin(&tmp)
         .args(["scan", dir_a.to_str().unwrap(), dir_b.to_str().unwrap()])
-        .assert().success();
+        .assert()
+        .success();
 
     // both files findable
     for term in ["one.txt", "two.txt"] {
-        marlin(&tmp).args(["search", term])
+        marlin(&tmp)
+            .args(["search", term])
             .assert()
             .success()
             .stdout(str::contains(term));
     }
 }
-

--- a/cli-bin/tests/util.rs
+++ b/cli-bin/tests/util.rs
@@ -1,9 +1,9 @@
 //! tests/util.rs
 //! Small helpers shared across integration tests.
 
+use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
-use assert_cmd::Command; 
 /// Absolute path to the freshly-built `marlin` binary.
 pub fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_marlin"))

--- a/cli-bin/tests/watch_unit.rs
+++ b/cli-bin/tests/watch_unit.rs
@@ -2,11 +2,11 @@ use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;
 
-use marlin_cli::cli::{watch, Format};
-use marlin_cli::cli::watch::WatchCmd;
+use libc;
 use libmarlin::watcher::WatcherState;
 use libmarlin::{self as marlin, db};
-use libc;
+use marlin_cli::cli::watch::WatchCmd;
+use marlin_cli::cli::{watch, Format};
 
 #[test]
 fn watch_start_and_stop_quickly() {
@@ -20,7 +20,10 @@ fn watch_start_and_stop_quickly() {
     let mut conn = db::open(&db_path).unwrap();
 
     let path = tmp.path().to_path_buf();
-    let cmd = WatchCmd::Start { path: path.clone(), debounce_ms: 50 };
+    let cmd = WatchCmd::Start {
+        path: path.clone(),
+        debounce_ms: 50,
+    };
 
     // send SIGINT shortly after watcher starts
     let t = thread::spawn(|| {

--- a/libmarlin/src/db/database.rs
+++ b/libmarlin/src/db/database.rs
@@ -1,21 +1,21 @@
 //! Database abstraction for Marlin
-//! 
+//!
 //! This module provides a database abstraction layer that wraps the SQLite connection
 //! and provides methods for common database operations.
 
+use anyhow::Result;
 use rusqlite::Connection;
 use std::path::PathBuf;
-use anyhow::Result;
 
 /// Options for indexing files
 #[derive(Debug, Clone)]
 pub struct IndexOptions {
     /// Only update files marked as dirty
     pub dirty_only: bool,
-    
+
     /// Index file contents (not just metadata)
     pub index_contents: bool,
-    
+
     /// Maximum file size to index (in bytes)
     pub max_size: Option<u64>,
 }
@@ -41,32 +41,34 @@ impl Database {
     pub fn new(conn: Connection) -> Self {
         Self { conn }
     }
-    
+
     /// Get a reference to the underlying connection
     pub fn conn(&self) -> &Connection {
         &self.conn
     }
-    
+
     /// Get a mutable reference to the underlying connection
     pub fn conn_mut(&mut self) -> &mut Connection {
         &mut self.conn
     }
-    
+
     /// Index one or more files
     pub fn index_files(&mut self, paths: &[PathBuf], _options: &IndexOptions) -> Result<usize> {
         // In a real implementation, this would index the files
         // For now, we just return the number of files "indexed"
-        if paths.is_empty() { // Add a branch for coverage
+        if paths.is_empty() {
+            // Add a branch for coverage
             return Ok(0);
         }
         Ok(paths.len())
     }
-    
+
     /// Remove files from the index
     pub fn remove_files(&mut self, paths: &[PathBuf]) -> Result<usize> {
         // In a real implementation, this would remove the files
         // For now, we just return the number of files "removed"
-        if paths.is_empty() { // Add a branch for coverage
+        if paths.is_empty() {
+            // Add a branch for coverage
             return Ok(0);
         }
         Ok(paths.len())
@@ -77,8 +79,8 @@ impl Database {
 mod tests {
     use super::*;
     use crate::db::open as open_marlin_db; // Use your project's DB open function
-    use tempfile::tempdir;
     use std::fs::File;
+    use tempfile::tempdir;
 
     fn setup_db() -> Database {
         let conn = open_marlin_db(":memory:").expect("Failed to open in-memory DB");
@@ -102,7 +104,7 @@ mod tests {
 
         let paths = vec![file1.to_path_buf()];
         let options = IndexOptions::default();
-        
+
         assert_eq!(db.index_files(&paths, &options).unwrap(), 1);
         assert_eq!(db.index_files(&[], &options).unwrap(), 0); // Test empty case
     }
@@ -115,7 +117,7 @@ mod tests {
         File::create(&file1).unwrap(); // File doesn't need to be in DB for this stub
 
         let paths = vec![file1.to_path_buf()];
-        
+
         assert_eq!(db.remove_files(&paths).unwrap(), 1);
         assert_eq!(db.remove_files(&[]).unwrap(), 0); // Test empty case
     }

--- a/libmarlin/src/db/mod.rs
+++ b/libmarlin/src/db/mod.rs
@@ -9,27 +9,38 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use std::result::Result as StdResult;
 use anyhow::{Context, Result};
 use chrono::Local;
 use rusqlite::{
     backup::{Backup, StepResult},
-    params,
-    Connection,
-    OpenFlags,
-    OptionalExtension,
-    TransactionBehavior,
+    params, Connection, OpenFlags, OptionalExtension, TransactionBehavior,
 };
+use std::result::Result as StdResult;
 use tracing::{debug, info, warn};
 
 /* ─── embedded migrations ─────────────────────────────────────────── */
 
 const MIGRATIONS: &[(&str, &str)] = &[
-    ("0001_initial_schema.sql", include_str!("migrations/0001_initial_schema.sql")),
-    ("0002_update_fts_and_triggers.sql", include_str!("migrations/0002_update_fts_and_triggers.sql")),
-    ("0003_create_links_collections_views.sql", include_str!("migrations/0003_create_links_collections_views.sql")),
-    ("0004_fix_hierarchical_tags_fts.sql", include_str!("migrations/0004_fix_hierarchical_tags_fts.sql")),
-    ("0005_add_dirty_table.sql", include_str!("migrations/0005_add_dirty_table.sql")),
+    (
+        "0001_initial_schema.sql",
+        include_str!("migrations/0001_initial_schema.sql"),
+    ),
+    (
+        "0002_update_fts_and_triggers.sql",
+        include_str!("migrations/0002_update_fts_and_triggers.sql"),
+    ),
+    (
+        "0003_create_links_collections_views.sql",
+        include_str!("migrations/0003_create_links_collections_views.sql"),
+    ),
+    (
+        "0004_fix_hierarchical_tags_fts.sql",
+        include_str!("migrations/0004_fix_hierarchical_tags_fts.sql"),
+    ),
+    (
+        "0005_add_dirty_table.sql",
+        include_str!("migrations/0005_add_dirty_table.sql"),
+    ),
 ];
 
 /* ─── connection bootstrap ────────────────────────────────────────── */
@@ -237,10 +248,7 @@ pub fn list_links(
     Ok(out)
 }
 
-pub fn find_backlinks(
-    conn: &Connection,
-    pattern: &str,
-) -> Result<Vec<(String, Option<String>)>> {
+pub fn find_backlinks(conn: &Connection, pattern: &str) -> Result<Vec<(String, Option<String>)>> {
     let like = pattern.replace('*', "%");
 
     let mut stmt = conn.prepare(
@@ -318,11 +326,9 @@ pub fn list_views(conn: &Connection) -> Result<Vec<(String, String)>> {
 }
 
 pub fn view_query(conn: &Connection, name: &str) -> Result<String> {
-    conn.query_row(
-        "SELECT query FROM views WHERE name = ?1",
-        [name],
-        |r| r.get::<_, String>(0),
-    )
+    conn.query_row("SELECT query FROM views WHERE name = ?1", [name], |r| {
+        r.get::<_, String>(0)
+    })
     .context(format!("no view called '{}'", name))
 }
 

--- a/libmarlin/src/db_tests.rs
+++ b/libmarlin/src/db_tests.rs
@@ -90,7 +90,9 @@ fn file_id_returns_id_and_errors_on_missing() {
 
     // fetch its id via raw SQL
     let fid: i64 = conn
-        .query_row("SELECT id FROM files WHERE path='exist.txt'", [], |r| r.get(0))
+        .query_row("SELECT id FROM files WHERE path='exist.txt'", [], |r| {
+            r.get(0)
+        })
         .unwrap();
 
     // db::file_id should return the same id for existing paths
@@ -116,10 +118,14 @@ fn add_and_remove_links_and_backlinks() {
     )
     .unwrap();
     let src: i64 = conn
-        .query_row("SELECT id FROM files WHERE path='one.txt'", [], |r| r.get(0))
+        .query_row("SELECT id FROM files WHERE path='one.txt'", [], |r| {
+            r.get(0)
+        })
         .unwrap();
     let dst: i64 = conn
-        .query_row("SELECT id FROM files WHERE path='two.txt'", [], |r| r.get(0))
+        .query_row("SELECT id FROM files WHERE path='two.txt'", [], |r| {
+            r.get(0)
+        })
         .unwrap();
 
     // add a link of type "ref"
@@ -193,8 +199,11 @@ fn backup_and_restore_cycle() {
 
     // reopen and check that x.bin survived
     let conn2 = db::open(&db_path).unwrap();
-    let cnt: i64 =
-        conn2.query_row("SELECT COUNT(*) FROM files WHERE path='x.bin'", [], |r| r.get(0)).unwrap();
+    let cnt: i64 = conn2
+        .query_row("SELECT COUNT(*) FROM files WHERE path='x.bin'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
     assert_eq!(cnt, 1);
 }
 
@@ -210,7 +219,9 @@ mod dirty_helpers {
         )
         .unwrap();
         let fid: i64 = conn
-            .query_row("SELECT id FROM files WHERE path='dummy.txt'", [], |r| r.get(0))
+            .query_row("SELECT id FROM files WHERE path='dummy.txt'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
 
         db::mark_dirty(&conn, fid).unwrap();

--- a/libmarlin/src/facade_tests.rs
+++ b/libmarlin/src/facade_tests.rs
@@ -1,6 +1,6 @@
 // libmarlin/src/facade_tests.rs
 
-use super::*;             // brings Marlin, config, etc.
+use super::*; // brings Marlin, config, etc.
 use std::{env, fs};
 use tempfile::tempdir;
 
@@ -71,4 +71,3 @@ fn open_default_fallback_config() {
     // Clean up
     env::remove_var("HOME");
 }
-

--- a/libmarlin/src/logging.rs
+++ b/libmarlin/src/logging.rs
@@ -9,9 +9,9 @@ pub fn init() {
     // All tracing output (INFO, WARN, ERROR …) now goes to *stderr* so the
     // integration tests can assert on warnings / errors reliably.
     fmt()
-        .with_target(false)        // hide module targets
-        .with_level(true)          // include log level
-        .with_env_filter(filter)   // respect RUST_LOG
+        .with_target(false) // hide module targets
+        .with_level(true) // include log level
+        .with_env_filter(filter) // respect RUST_LOG
         .with_writer(std::io::stderr) // <-- NEW: send to stderr
         .init();
 }

--- a/libmarlin/src/scan_tests.rs
+++ b/libmarlin/src/scan_tests.rs
@@ -1,9 +1,9 @@
 // libmarlin/src/scan_tests.rs
 
-use super::scan::scan_directory;
 use super::db;
-use tempfile::tempdir;
+use super::scan::scan_directory;
 use std::fs::File;
+use tempfile::tempdir;
 
 #[test]
 fn scan_directory_counts_files() {

--- a/libmarlin/src/utils.rs
+++ b/libmarlin/src/utils.rs
@@ -21,7 +21,10 @@ pub fn determine_scan_root(pattern: &str) -> PathBuf {
 
     // If there were NO wildcards at all, just return the parent directory
     if first_wild == pattern.len() {
-        return root.parent().map(|p| p.to_path_buf()).unwrap_or_else(|| PathBuf::from("."));
+        return root
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
     }
 
     // Otherwise, if the prefix still has any wildcards (e.g. "foo*/bar"),


### PR DESCRIPTION
## Summary
- run rustfmt across the workspace

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings` *(fails: needless_borrows_for_generic_args, format-in-format-args)*
- `./run_all_tests.sh`