### PR TITLE
Fix CLI build script lookups and clippy lints

### DIFF
--- a/cli-bin/build.rs
+++ b/cli-bin/build.rs
@@ -29,12 +29,12 @@ fn generate_cheatsheet() -> Result<(), Box<dyn std::error::Error>> {
             let cmd_name = cmd_name_val.as_str().unwrap_or("");
             if let Value::Mapping(cmd_details) = cmd_details_val {
                 if let Some(Value::Mapping(actions)) =
-                    cmd_details.get(&Value::String("actions".into()))
+                    cmd_details.get(Value::String("actions".into()))
                 {
                     for (action_name_val, action_body_val) in actions {
                         let action_name = action_name_val.as_str().unwrap_or("");
                         let flags = if let Value::Mapping(action_map) = action_body_val {
-                            match action_map.get(&Value::String("flags".into())) {
+                            match action_map.get(Value::String("flags".into())) {
                                 Some(Value::Sequence(seq)) => seq
                                     .iter()
                                     .filter_map(|v| v.as_str())
@@ -48,9 +48,8 @@ fn generate_cheatsheet() -> Result<(), Box<dyn std::error::Error>> {
 
                         let flags_disp = if flags.is_empty() { "—" } else { &flags };
                         table.push_str(&format!(
-                            "| `{}` | {} |\n",
-                            format!("{} {}", cmd_name, action_name),
-                            flags_disp
+                            "| `{} {}` | {} |\n",
+                            cmd_name, action_name, flags_disp
                         ));
                     }
                 }

--- a/cli-bin/src/main.rs
+++ b/cli-bin/src/main.rs
@@ -16,8 +16,6 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use glob::Pattern;
-use shellexpand;
-use shlex;
 use std::{env, fs, io, path::Path, process::Command};
 use tracing::{debug, error, info};
 use walkdir::WalkDir;
@@ -293,13 +291,11 @@ fn run_search(conn: &rusqlite::Connection, raw_query: &str, exec: Option<String>
 
     if let Some(cmd_tpl) = exec {
         run_exec(&hits, &cmd_tpl)?;
+    } else if hits.is_empty() {
+        eprintln!("No matches for query: `{raw_query}` (FTS expr: `{fts_expr}`)");
     } else {
-        if hits.is_empty() {
-            eprintln!("No matches for query: `{raw_query}` (FTS expr: `{fts_expr}`)");
-        } else {
-            for p in hits {
-                println!("{p}");
-            }
+        for p in hits {
+            println!("{p}");
         }
     }
     Ok(())

--- a/libmarlin/src/utils.rs
+++ b/libmarlin/src/utils.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 pub fn determine_scan_root(pattern: &str) -> PathBuf {
     // find first wildcard char
     let first_wild = pattern
-        .find(|c| matches!(c, '*' | '?' | '['))
+        .find(|c| ['*', '?', '['].contains(&c))
         .unwrap_or(pattern.len());
 
     // everything up to the wildcard (or the whole string if none)

--- a/libmarlin/src/watcher.rs
+++ b/libmarlin/src/watcher.rs
@@ -421,7 +421,7 @@ impl FileWatcher {
                                 };
                                 debouncer.add_event(ProcessedEvent {
                                     path,
-                                    kind: event.kind.clone(),
+                                    kind: event.kind,
                                     priority: prio,
                                     timestamp: Instant::now(),
                                 });


### PR DESCRIPTION
## Summary
- fix key lookups in CLI build script
- simplify CLI result handling
- tidy utils and watcher for clippy

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`