### PR TITLE
Fix cheatsheet path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: marlin-cli-cheatsheet
-          path: docs/cli_cheatsheet.md
+          path: cli-bin/docs/cli_cheatsheet.md
           if-no-files-found: warn
           retention-days: 7
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Before a milestone is declared **shipped**:
 ## CLI Cheatsheet
 
 The full command reference is generated during the build of the CLI. See
-[docs/cli_cheatsheet.md](docs/cli_cheatsheet.md).
+[cli-bin/docs/cli_cheatsheet.md](cli-bin/docs/cli_cheatsheet.md).
 
 ## License
 

--- a/cli-bin/build.rs
+++ b/cli-bin/build.rs
@@ -2,7 +2,7 @@
 //
 // Build script to generate the CLI cheatsheet at compile time.  It
 // parses `src/cli/commands.yaml` and emits a simple Markdown table of
-// commands and flags to `docs/cli_cheatsheet.md`.
+// commands and flags to `cli-bin/docs/cli_cheatsheet.md`.
 
 use std::{fs, path::Path};
 


### PR DESCRIPTION
## Summary
- generate CLI cheatsheet under `cli-bin/docs`
- update README reference
- update CI artefact path

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: interrupted)*