### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (stable)
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           override: true
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust (nightly for Tarpaulin, if needed)
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: nightly # Or stable if Tarpaulin works well with it for your project
           override: true

--- a/.github/workflows/nightly-backup-prune.yml
+++ b/.github/workflows/nightly-backup-prune.yml
@@ -25,16 +25,16 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
           toolchain: stable
       
       - name: Build Marlin CLI
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.3
         with:
           command: build
           args: --release --bin marlin


### PR DESCRIPTION
## Summary
- bump Rust toolchain and cargo action versions
- update checkout version in nightly prune workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`