### PR TITLE
Fix CLI cheatsheet artifact path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: marlin-cli-cheatsheet
-          path: cli-bin/docs/cli_cheatsheet.md
+          path: ${{ github.workspace }}/docs/cli_cheatsheet.md
           if-no-files-found: warn
           retention-days: 7
 


### PR DESCRIPTION
## Summary
- fix path for CLI cheatsheet artifact in CI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`