### PR TITLE
Fix restore with backup ID

### DIFF
--- a/cli-bin/src/main.rs
+++ b/cli-bin/src/main.rs
@@ -11,6 +11,7 @@ mod cli; // sub-command definitions and argument structs
 /* ── shared modules re-exported from libmarlin ─────────────────── */
 use libmarlin::db::take_dirty;
 use libmarlin::{config, db, logging, scan, utils::determine_scan_root};
+use libmarlin::backup::BackupManager;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
@@ -106,8 +107,20 @@ fn main() -> Result<()> {
 
         Commands::Restore { backup_path } => {
             drop(conn);
-            db::restore(&backup_path, &cfg.db_path)
-                .with_context(|| format!("Failed to restore DB from {}", backup_path.display()))?;
+            if backup_path.exists() {
+                db::restore(&backup_path, &cfg.db_path)
+                    .with_context(|| format!("Failed to restore DB from {}", backup_path.display()))?;
+            } else {
+                let backups_dir = cfg.db_path.parent().unwrap().join("backups");
+                let manager = BackupManager::new(&cfg.db_path, &backups_dir)?;
+                let name = backup_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .context("invalid backup file name")?;
+                manager
+                    .restore_from_backup(name)
+                    .with_context(|| format!("Failed to restore DB from {}", backup_path.display()))?;
+            }
             println!("Restored DB from {}", backup_path.display());
             db::open(&cfg.db_path).with_context(|| {
                 format!("Could not open restored DB at {}", cfg.db_path.display())


### PR DESCRIPTION
## Summary
- allow `marlin restore` to accept a backup filename
- search the default backups directory when the path does not exist

## Testing
- `cargo fmt --all -- --check` *(fails: could not download toolchain)*
- `cargo clippy -- -D warnings` *(fails: could not download toolchain)*
- `./run_all_tests.sh` *(fails: could not download toolchain)*