### PR TITLE
Remove canonical_id from tags

### DIFF
--- a/libmarlin/src/db/migrations/0001_initial_schema.sql
+++ b/libmarlin/src/db/migrations/0001_initial_schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS tags (
     id           INTEGER PRIMARY KEY,
     name         TEXT    NOT NULL,           -- tag segment
     parent_id    INTEGER REFERENCES tags(id) ON DELETE CASCADE,
-    canonical_id INTEGER REFERENCES tags(id) ON DELETE SET NULL,
     UNIQUE(name, parent_id)
 );
 

--- a/libmarlin/src/db/migrations/0006_drop_tags_canonical_id.sql
+++ b/libmarlin/src/db/migrations/0006_drop_tags_canonical_id.sql
@@ -1,0 +1,6 @@
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+-- Remove canonical_id column from tags table
+ALTER TABLE tags DROP COLUMN canonical_id;
+

--- a/libmarlin/src/db/mod.rs
+++ b/libmarlin/src/db/mod.rs
@@ -41,6 +41,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0005_add_dirty_table.sql",
         include_str!("migrations/0005_add_dirty_table.sql"),
     ),
+    (
+        "0006_drop_tags_canonical_id.sql",
+        include_str!("migrations/0006_drop_tags_canonical_id.sql"),
+    ),
 ];
 
 /* ─── connection bootstrap ────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- drop `canonical_id` column from `tags` in initial schema
- add migration `0006_drop_tags_canonical_id.sql`
- embed new migration in db module

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*
