### PR TITLE
Fix migrations when opening new DB

### DIFF
--- a/libmarlin/src/db/migrations/0001_initial_schema.sql
+++ b/libmarlin/src/db/migrations/0001_initial_schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS tags (
     id           INTEGER PRIMARY KEY,
     name         TEXT    NOT NULL,           -- tag segment
     parent_id    INTEGER REFERENCES tags(id) ON DELETE CASCADE,
+    canonical_id INTEGER REFERENCES tags(id),
     UNIQUE(name, parent_id)
 );
 

--- a/libmarlin/src/db/mod.rs
+++ b/libmarlin/src/db/mod.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 /* ─── schema version ───────────────────────────────────────────────── */
 
 /// Current library schema version.
-pub const SCHEMA_VERSION: i32 = 1_1;
+pub const SCHEMA_VERSION: i32 = MIGRATIONS.len() as i32;
 
 /* ─── embedded migrations ─────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- add missing `canonical_id` column to initial DB schema
- set schema version dynamically using embedded migration count

## Testing
- `cargo test db::tests::migrations_apply_in_memory -- --nocapture`
- `cargo test --all` *(fails: db_tests::tables_exist_and_fts_triggers)*