### PR TITLE
Fix env var leakage in config tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "crossbeam-channel",
  "directories",
  "glob",
+ "lazy_static",
  "notify",
  "priority-queue",
  "rusqlite",

--- a/libmarlin/Cargo.toml
+++ b/libmarlin/Cargo.toml
@@ -27,6 +27,7 @@ json = ["serde_json"]
 [dev-dependencies]
 # for temporary directories in config_tests.rs and scan_tests.rs
 tempfile = "3"
+lazy_static = "1"
 
 # you already have rusqlite in [dependencies], so scan_tests.rs
 # can just use rusqlite::Connection, no need to repeat it here.

--- a/libmarlin/src/config_tests.rs
+++ b/libmarlin/src/config_tests.rs
@@ -1,11 +1,13 @@
 // libmarlin/src/config_tests.rs
 
 use super::config::Config;
+use crate::test_utils::ENV_MUTEX;
 use std::env;
 use tempfile::tempdir;
 
 #[test]
 fn load_env_override() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     let tmp = tempdir().unwrap();
     let db = tmp.path().join("custom.db");
     env::set_var("MARLIN_DB_PATH", &db);
@@ -16,6 +18,7 @@ fn load_env_override() {
 
 #[test]
 fn load_xdg_or_fallback() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     // since XDG_DATA_HOME will normally be present, just test it doesn't error
     let cfg = Config::load().unwrap();
     assert!(cfg.db_path.to_string_lossy().ends_with(".db"));
@@ -23,6 +26,7 @@ fn load_xdg_or_fallback() {
 
 #[test]
 fn load_fallback_current_dir() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     // Save and clear HOME & XDG_DATA_HOME
     let orig_home = env::var_os("HOME");
     let orig_xdg = env::var_os("XDG_DATA_HOME");

--- a/libmarlin/src/facade_tests.rs
+++ b/libmarlin/src/facade_tests.rs
@@ -1,11 +1,13 @@
 // libmarlin/src/facade_tests.rs
 
 use super::*; // brings Marlin, config, etc.
+use crate::test_utils::ENV_MUTEX;
 use std::{env, fs};
 use tempfile::tempdir;
 
 #[test]
 fn open_at_and_scan_and_search() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     // 1) Prepare a temp workspace with one file
     let tmp = tempdir().unwrap();
     let file = tmp.path().join("hello.txt");
@@ -33,6 +35,7 @@ fn open_at_and_scan_and_search() {
 
 #[test]
 fn tag_and_search_by_tag() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     let tmp = tempdir().unwrap();
     let a = tmp.path().join("a.md");
     let b = tmp.path().join("b.md");
@@ -56,6 +59,7 @@ fn tag_and_search_by_tag() {
 
 #[test]
 fn open_default_fallback_config() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     // Unset all overrides
     env::remove_var("MARLIN_DB_PATH");
     env::remove_var("XDG_DATA_HOME");

--- a/libmarlin/src/lib.rs
+++ b/libmarlin/src/lib.rs
@@ -27,6 +27,8 @@ mod logging_tests;
 #[cfg(test)]
 mod scan_tests;
 #[cfg(test)]
+mod test_utils;
+#[cfg(test)]
 mod utils_tests;
 #[cfg(test)]
 mod watcher_tests;

--- a/libmarlin/src/test_utils.rs
+++ b/libmarlin/src/test_utils.rs
@@ -1,0 +1,8 @@
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Global mutex to serialize environment-variable modifications in tests.
+    pub static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
+}


### PR DESCRIPTION
## Summary
- add a global ENV_MUTEX for tests that modify env vars
- lock env access in config and facade tests
- expose new test_utils module for shared helpers

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --all -- --nocapture`