### PR TITLE
Add placeholder ADRs for roadmap DPs

### DIFF
--- a/docs/adr/DP-002_dirty-flag.md
+++ b/docs/adr/DP-002_dirty-flag.md
@@ -1,0 +1,7 @@
+# DP-002: Dirty Flag Design & FTS Rebuild Cadence
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+This placeholder reserves the DP number for the dirty-scan design proposal described in the roadmap. Details will be filled in once the full specification is drafted.

--- a/docs/adr/DP-004_content-blob_strategy.md
+++ b/docs/adr/DP-004_content-blob_strategy.md
@@ -1,0 +1,7 @@
+# DP-004: Content-Blob Strategy (Inline vs External Table)
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Reserved for the proposal covering how file contents are stored and indexed for full-text search and annotations.

--- a/docs/adr/DP-005_hash_and_dedupe.md
+++ b/docs/adr/DP-005_hash_and_dedupe.md
@@ -1,0 +1,7 @@
+# DP-005: Hash Column & Bloom-Based Deduplication
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Reserved for the proposal defining SHA-256 hashing and duplicate detection via Bloom filters.

--- a/docs/adr/DP-006_embeddings_and_models.md
+++ b/docs/adr/DP-006_embeddings_and_models.md
@@ -1,0 +1,7 @@
+# DP-006: Embeddings Size & Model Choice
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Placeholder for design decisions around semantic embeddings, vector store schema, and model selection.

--- a/docs/adr/DP-007_search_dsl_v2.md
+++ b/docs/adr/DP-007_search_dsl_v2.md
@@ -1,0 +1,7 @@
+# DP-007: Search DSL v2 Grammar
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Reserved for the formal grammar and parser design for the advanced search language.

--- a/docs/adr/DP-008_workflow_tables.md
+++ b/docs/adr/DP-008_workflow_tables.md
@@ -1,0 +1,7 @@
+# DP-008: Workflow Tables & Validation
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Placeholder for the schema and validation rules supporting structured workflows and relationship templates.

--- a/docs/adr/DP-009_tui_keymap.md
+++ b/docs/adr/DP-009_tui_keymap.md
@@ -1,0 +1,7 @@
+# DP-009: TUI Key Map & Redraw Budget
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Reserved for the design of keyboard interactions and performance targets for the TUI.

--- a/docs/adr/DP-010_kde_sidebar.md
+++ b/docs/adr/DP-010_kde_sidebar.md
@@ -1,0 +1,7 @@
+# DP-010: DB/IP Bridge for KDE Sidebar
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Placeholder for communication mechanisms and packaging strategy for the Dolphin sidebar integration.

--- a/docs/adr/DP-011_sync_backend.md
+++ b/docs/adr/DP-011_sync_backend.md
@@ -1,0 +1,7 @@
+# DP-011: Sync Backend Trade-Study
+
+**Status**: Pending
+**Authors**: TBA
+**Date**: 2025-05-19
+
+Reserved for evaluation of synchronization approaches and end-to-end UI test plan.


### PR DESCRIPTION
## Summary
- add placeholders DP-002 through DP-011 under docs/adr

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`