### PR TITLE
Docs: reflect alias schema removal

### DIFF
--- a/docs/adr/DP-001_schema_v1.1.md
+++ b/docs/adr/DP-001_schema_v1.1.md
@@ -8,14 +8,14 @@
 
 We’ve landed a basic SQLite-backed `files` table and a contentless FTS5 index. Before we build out higher-level features, we need to lock down our **v1.1** metadata schema for:
 
-- **Hierarchical tags** (`tags` + `file_tags`) – optional `canonical_id` for aliases
+- **Hierarchical tags** (`tags` + `file_tags`) – alias resolution handled at query time
 - **Custom attributes** (`attributes`)
 - **File-to-file relationships** (`links`)
 - **Named collections** (`collections` + `collection_files`)
 - **Views** (`views`)
 
-Locking this schema now lets downstream CLI & GUI work against a stable model and ensures our migrations stay easy to reason about.  
-Tags optionally reference a canonical tag via the `canonical_id` column.
+Locking this schema now lets downstream CLI & GUI work against a stable model and ensures our migrations stay easy to reason about.
+Alias relationships are resolved outside the table itself; there is no `canonical_id` column.
 
 ## 2. Decision
 
@@ -58,7 +58,6 @@ entity tags {
   --
     name      : TEXT
     parent_id : INTEGER <<FK>>
-    canonical_id : INTEGER <<FK>>
 }
 
 entity file_tags {
@@ -151,6 +150,7 @@ Or in plain-ASCII:
 | **0003\_create\_links\_collections\_views.sql** | Add `links`, `collections`, `collection_files`, `views` |
 | **0004\_fix\_hierarchical\_tags\_fts.sql**             | Recursive CTE for full tag-path indexing in FTS triggers      |
 | **0005_add_dirty_table.sql**                           | Track modified files needing reindexing |
+| **0006_drop_tags_canonical_id.sql**                   | Remove legacy `canonical_id` column from `tags` |
 
 ### Performance-Critical Indexes
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ Before a milestone is declared “shipped”:
 | - | ------------------------------ | ------ | ------------- |
 | ~~1~~ | ~~Crate split + CI baseline~~      | @alice | ~~26 May 25~~ |
 | ~~2~~ | ~~Tarpaulin + Hyperfine jobs~~     | @bob   | ~~26 May 25~~ |
-| 3 | **DP‑001 Schema v1.1** draft   | @carol | **30 May 25** |
+| ~~3~~ | ~~DP‑001 Schema v1.1 draft~~   | @carol | ~~30 May 25~~ |
 | ~~4~~ | ~~backup prune CLI + nightly job~~ | @dave  | ~~05 Jun 25~~ |
 
 > *This roadmap now contains both product-level “what” and engineering-level “how/when/prove it”.  It should allow a new contributor to jump in, pick the matching DP, and know exactly the bar they must clear for their code to merge.*  

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -8,7 +8,7 @@
 
 | Feature Area                        | Capabilities                                                                                                                                                                                                                                                                                                                             |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Tagging System**                  | • Unlimited, hierarchical or flat tags.<br>• Alias/synonym support with precedence rules (admin‑defined canonical name).<br>• **Bulk tag editing** via multi‑select context menu.<br>• Folder‑to‑Tag import with optional *watch & sync* mode so new sub‑folders inherit tags automatically.                                             |
+| **Tagging System**                  | • Unlimited, hierarchical or flat tags.<br>• Alias/synonym support via admin‑defined mappings (canonical names resolved at query time).<br>• **Bulk tag editing** via multi‑select context menu.<br>• Folder‑to‑Tag import with optional *watch & sync* mode so new sub‑folders inherit tags automatically.                                             |
 | **Custom Metadata Attributes**      | • User‑defined fields (text, number, date, enum, boolean).<br>• Per‑template **Custom Metadata Schemas** (e.g. *Photo* → *Date, Location*).                                                                                                                                                                                              |
 | **File Relationships**              | • Typed, directional or bidirectional links (*related to*, *duplicate of*, *cites*…).<br>• Plugin API can register new relationship sets.                                                                                                                                                                                                |
 | **Version Control for Metadata**    | • Every change logged; unlimited roll‑back.<br>• Side‑by‑side diff viewer and *blame* panel showing *who/when/what*.<br>• Offline edits stored locally and merged (Git‑style optimistic merge with conflict prompts).                                                                                                                    |
@@ -36,7 +36,7 @@
 
 ```text
 files(id PK, path, inode, size, mtime, ctime, hash)
-tags(id PK, name, parent_id, canonical_id)
+tags(id PK, name, parent_id)
 file_tags(file_id FK, tag_id FK)
 attributes(id PK, file_id FK, key, value, value_type)
 relationships(id PK, src_file_id FK, dst_file_id FK, rel_type, direction)


### PR DESCRIPTION
## Summary
- update DP-001 docs to drop `canonical_id`
- remove `canonical_id` column from vision schema snippet
- mention new migration and alias approach
- mark roadmap item for DP-001 as complete

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails to fully run in this environment)*