### PR TITLE
Format watcher module

### DIFF
--- a/libmarlin/src/watcher.rs
+++ b/libmarlin/src/watcher.rs
@@ -520,15 +520,16 @@ impl FileWatcher {
             let _ = h.join();
         }
 
-        *self
-            .state
-            .lock()
-            .map_err(|_| anyhow::anyhow!("state"))? = WatcherState::Stopped;
+        *self.state.lock().map_err(|_| anyhow::anyhow!("state"))? = WatcherState::Stopped;
         Ok(())
     }
 
     pub fn status(&self) -> Result<WatcherStatus> {
-        let st = self.state.lock().map_err(|_| anyhow::anyhow!("state"))?.clone();
+        let st = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("state"))?
+            .clone();
         Ok(WatcherStatus {
             state: st,
             events_processed: self.events_processed.load(Ordering::SeqCst),


### PR DESCRIPTION
## Summary
- run `cargo fmt` on watcher

## Testing
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*
