### PR TITLE
Add inode-based rename detection

### DIFF
--- a/libmarlin/Cargo.toml
+++ b/libmarlin/Cargo.toml
@@ -18,6 +18,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 walkdir            = "2.5"
 shlex              = "1.3"
+same-file         = "1"
 shellexpand        = "3.1"
 serde_json         = { version = "1", optional = true }
 


### PR DESCRIPTION
## Summary
- track pending removes in a new `RemoveTracker`
- synthesize `Modify(Name(Both))` when a create shares an inode with a recent remove
- flush orphaned removes after the timeout
- test rename synthesis via `RemoveTracker`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`