### PR TITLE
Replace eprintln! with tracing macros

### DIFF
--- a/libmarlin/src/watcher.rs
+++ b/libmarlin/src/watcher.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-use tracing::info;
+use tracing::{error, info};
 
 // ────── configuration ─────────────────────────────────────────────────────────
 #[derive(Debug, Clone)]
@@ -369,7 +369,7 @@ impl FileWatcher {
                                 }
                             } // end match event.kind
                         } // <--- closes Ok(event)
-                        Err(e) => eprintln!("watcher channel error: {:?}", e),
+                        Err(e) => error!("watcher channel error: {:?}", e),
                     }
 
                     if processed_in_batch >= config_clone.batch_size {
@@ -423,7 +423,7 @@ impl FileWatcher {
                                         )
                                     };
                                     if let Err(e) = res {
-                                        eprintln!("DB rename error: {:?}", e);
+                                        error!("DB rename error: {:?}", e);
                                     }
                                 }
                             }

--- a/libmarlin/src/watcher_tests.rs
+++ b/libmarlin/src/watcher_tests.rs
@@ -11,13 +11,23 @@ mod tests {
 
     use std::fs::{self, File};
     use std::io::Write;
+    use std::sync::Once;
     // No longer need: use std::path::PathBuf;
     use std::thread;
     use std::time::Duration;
     use tempfile::tempdir;
 
+    static INIT: Once = Once::new();
+
+    fn init_logging() {
+        INIT.call_once(|| {
+            crate::logging::init();
+        });
+    }
+
     #[test]
     fn test_watcher_lifecycle() {
+        init_logging();
         // Create a temp directory for testing
         let temp_dir = tempdir().expect("Failed to create temp directory");
         let temp_path = temp_dir.path();
@@ -73,6 +83,7 @@ mod tests {
 
     #[test]
     fn test_backup_manager_related_functionality() {
+        init_logging();
         let live_db_tmp_dir = tempdir().expect("Failed to create temp directory for live DB");
         let backups_storage_tmp_dir =
             tempdir().expect("Failed to create temp directory for backups storage");
@@ -148,6 +159,7 @@ mod tests {
 
     #[test]
     fn rename_file_updates_db() {
+        init_logging();
         let tmp = tempdir().unwrap();
         let dir = tmp.path();
         let file = dir.join("a.txt");
@@ -190,6 +202,7 @@ mod tests {
 
     #[test]
     fn rename_directory_updates_children() {
+        init_logging();
         let tmp = tempdir().unwrap();
         let dir = tmp.path();
         let sub = dir.join("old");


### PR DESCRIPTION
## Summary
- warn when backup timestamps are ambiguous or invalid
- log errors in watcher via `tracing`
- initialise tracing in watcher and backup tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`