### PR TITLE
Remove unused priority-queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,12 +472,6 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -528,16 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -635,7 +619,6 @@ dependencies = [
  "glob",
  "lazy_static",
  "notify",
- "priority-queue",
  "rusqlite",
  "serde_json",
  "sha2",
@@ -875,16 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "priority-queue"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
-dependencies = [
- "autocfg",
- "indexmap 1.9.3",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1042,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/libmarlin/Cargo.toml
+++ b/libmarlin/Cargo.toml
@@ -11,7 +11,6 @@ crossbeam-channel  = "0.5"
 directories        = "5"
 glob               = "0.3"
 notify             = "6.0"
-priority-queue     = "1.3"
 rusqlite           = { version = "0.31", features = ["bundled", "backup"] }
 sha2               = "0.10"
 tracing            = "0.1"


### PR DESCRIPTION
## Summary
- drop `priority-queue` from `libmarlin`
- regenerate `Cargo.lock`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: leaving early)*
- `cargo test --workspace` *(fails: watcher tests fail)*