### PR TITLE
Implement rename trigger fix

### DIFF
--- a/libmarlin/src/db/migrations/0007_fix_rename_trigger.sql
+++ b/libmarlin/src/db/migrations/0007_fix_rename_trigger.sql
@@ -1,0 +1,20 @@
+-- src/db/migrations/0007_fix_rename_trigger.sql
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+-- Recreate files_fts_au_file trigger using INSERT OR REPLACE
+DROP TRIGGER IF EXISTS files_fts_au_file;
+CREATE TRIGGER files_fts_au_file
+AFTER UPDATE OF path ON files
+BEGIN
+    INSERT OR REPLACE INTO files_fts(rowid, path, tags_text, attrs_text)
+        SELECT NEW.id,
+               NEW.path,
+               (SELECT IFNULL(GROUP_CONCAT(t.name, ' '), '')
+                  FROM file_tags ft
+                  JOIN tags t ON ft.tag_id = t.id
+                 WHERE ft.file_id = NEW.id),
+               (SELECT IFNULL(GROUP_CONCAT(a.key || '=' || a.value, ' '), '')
+                  FROM attributes a
+                 WHERE a.file_id = NEW.id);
+END;

--- a/libmarlin/src/db/mod.rs
+++ b/libmarlin/src/db/mod.rs
@@ -50,6 +50,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0006_drop_tags_canonical_id.sql",
         include_str!("migrations/0006_drop_tags_canonical_id.sql"),
     ),
+    (
+        "0007_fix_rename_trigger.sql",
+        include_str!("migrations/0007_fix_rename_trigger.sql"),
+    ),
 ];
 
 /* ─── schema helpers ─────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- add migration 0007 to recreate `files_fts_au_file` trigger using `INSERT OR REPLACE`
- register new migration in `db::MIGRATIONS`

## Testing
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: rename tests still time out)*