### PR TITLE
Update docs about path slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ for the current delivery roadmap and schema.
 
 Follow the short walkthrough in
 [docs/marlin_demo.md](docs/marlin_demo.md) to build the
-binary and test Marlin on a sample project.
+binary and test Marlin on a sample project. Paths in the
+database are always stored with forward slashes (`/`), even
+on Windows.
+
+```powershell
+# PowerShell build example
+$env:CARGO_TARGET_DIR = "target"
+cargo build --release
+Copy-Item target\release\marlin.exe C:\Tools\marlin.exe
+```
 
 ## CLI Cheatsheet
 

--- a/docs/adr/DP-003_file-watcher_lifecycle.md
+++ b/docs/adr/DP-003_file-watcher_lifecycle.md
@@ -33,6 +33,7 @@ We'll implement a file-watcher system using the `notify` crate (which uses inoti
    - Batch database operations to minimize write transactions
    - Use the `--dirty` flag internally to optimize updates for changed files only
    - Implement a "catchup scan" on startup to handle changes that occurred while not watching
+   - Normalize all stored paths to use forward slashes (`/`) for portability
 
 4. **Backup & Pruning**:
    - Add `backup --prune N` to maintain only the N most recent backups


### PR DESCRIPTION
## Summary
- document forward-slash path storage in the file watcher DP
- add Windows PowerShell snippet and path note to README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`