### PR TITLE
Fix unused import warning on Windows

### DIFF
--- a/libmarlin/src/watcher.rs
+++ b/libmarlin/src/watcher.rs
@@ -13,6 +13,7 @@ use notify::{
     event::{ModifyKind, RemoveKind, RenameMode},
     Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcherTrait,
 };
+#[cfg(not(windows))]
 use same_file::Handle;
 use std::collections::HashMap;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- gate `same_file` import behind `cfg(not(windows))`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: generating corpus then exits)*