### PR TITLE
Fix windows test workflow error

### DIFF
--- a/cli-bin/src/cli/watch.rs
+++ b/cli-bin/src/cli/watch.rs
@@ -73,12 +73,12 @@ fn read_control(path: &Path) -> Result<ControlInfo> {
     Ok(serde_json::from_str(&txt)?)
 }
 
-fn process_alive(pid: u32) -> bool {
+fn process_alive(_pid: u32) -> bool {
     #[cfg(unix)]
     {
         use nix::sys::signal::kill;
         use nix::unistd::Pid;
-        kill(Pid::from_raw(pid as i32), None).is_ok()
+        kill(Pid::from_raw(_pid as i32), None).is_ok()
     }
     #[cfg(not(unix))]
     {


### PR DESCRIPTION
## Summary
- fix `process_alive` to ignore unused PID on Windows

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`