### PR TITLE
Fix windows test failures

### DIFF
--- a/libmarlin/src/db/mod.rs
+++ b/libmarlin/src/db/mod.rs
@@ -188,7 +188,8 @@ pub fn ensure_tag_path(conn: &Connection, path: &str) -> Result<i64> {
 }
 
 pub fn file_id(conn: &Connection, path: &str) -> Result<i64> {
-    conn.query_row("SELECT id FROM files WHERE path = ?1", [path], |r| r.get(0))
+    let path = to_db_path(path);
+    conn.query_row("SELECT id FROM files WHERE path = ?1", [path.clone()], |r| r.get(0))
         .map_err(|_| anyhow::anyhow!("file not indexed: {}", path))
 }
 

--- a/libmarlin/src/db_tests.rs
+++ b/libmarlin/src/db_tests.rs
@@ -193,6 +193,7 @@ fn backup_and_restore_cycle() {
 
     // backup
     let backup = db::backup(&db_path).unwrap();
+    drop(live); // close connection on Windows
     // remove original
     std::fs::remove_file(&db_path).unwrap();
     // restore


### PR DESCRIPTION
## Summary
- normalize paths when looking up file IDs
- close DB connection during backup tests
- use same_file handle for rename tracking on all platforms

## Testing
- `cargo fmt --all -- --check` *(fails: could not download file)*
- `cargo clippy -- -D warnings` *(fails: could not download file)*
- `./run_all_tests.sh` *(fails: could not download file)*