### PR TITLE
Fix formatting for db tests

### DIFF
--- a/libmarlin/src/db_tests.rs
+++ b/libmarlin/src/db_tests.rs
@@ -194,7 +194,7 @@ fn backup_and_restore_cycle() {
     // backup
     let backup = db::backup(&db_path).unwrap();
     drop(live); // close connection on Windows
-    // remove original
+                // remove original
     std::fs::remove_file(&db_path).unwrap();
     // restore
     db::restore(&backup, &db_path).unwrap();


### PR DESCRIPTION
## Summary
- ensure `db_tests` compiles by applying `cargo fmt`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`
