### PR TITLE
Fix path mismatch on Windows

### DIFF
--- a/libmarlin/src/utils.rs
+++ b/libmarlin/src/utils.rs
@@ -45,12 +45,28 @@ pub fn determine_scan_root(pattern: &str) -> PathBuf {
     }
 }
 
+/// Canonicalize a path, stripping any Windows device prefix ("\\?\") and
+/// falling back to the original on error.
+pub fn canonicalize_lossy<P: AsRef<Path>>(p: P) -> PathBuf {
+    let path = std::fs::canonicalize(&p).unwrap_or_else(|_| p.as_ref().to_path_buf());
+    #[cfg(windows)]
+    {
+        const VERBATIM_PREFIX: &str = "\\\\?\\";
+        let s = path.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix(VERBATIM_PREFIX) {
+            return PathBuf::from(stripped);
+        }
+    }
+    path
+}
+
 /// Convert a filesystem path to a normalized database path.
 ///
 /// On Windows this replaces backslashes with forward slashes so that paths
 /// stored in the database are consistent across platforms.
 pub fn to_db_path<P: AsRef<Path>>(p: P) -> String {
-    let s = p.as_ref().to_string_lossy();
+    let canonical = canonicalize_lossy(p);
+    let s = canonical.to_string_lossy();
     #[cfg(windows)]
     {
         s.replace('\\', "/")

--- a/libmarlin/src/watcher_tests.rs
+++ b/libmarlin/src/watcher_tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use crate::backup::BackupManager;
     // These are still from the watcher module
     use crate::db::open as open_marlin_db;
-    use crate::utils::to_db_path;
+    use crate::utils::{canonicalize_lossy, to_db_path};
     use crate::watcher::{FileWatcher, WatcherConfig, WatcherState}; // Use your project's DB open function
     use crate::Marlin;
 
@@ -25,12 +25,13 @@ mod tests {
         timeout: Duration,
     ) {
         let start = Instant::now();
+        let target = canonicalize_lossy(path);
         loop {
             let count: i64 = marlin
                 .conn()
                 .query_row(
                     "SELECT COUNT(*) FROM files WHERE path = ?1",
-                    [to_db_path(path)],
+                    [to_db_path(&target)],
                     |r| r.get(0),
                 )
                 .unwrap();
@@ -201,7 +202,12 @@ mod tests {
         thread::sleep(Duration::from_millis(100));
         let new_file = dir.join("b.txt");
         fs::rename(&file, &new_file).unwrap();
-        wait_for_row_count(&marlin, &new_file, 1, Duration::from_secs(10));
+        wait_for_row_count(
+            &marlin,
+            &canonicalize_lossy(&new_file),
+            1,
+            Duration::from_secs(10),
+        );
         watcher.stop().unwrap();
         assert!(
             watcher.status().unwrap().events_processed > 0,
@@ -249,7 +255,7 @@ mod tests {
         fs::rename(&sub, &new).unwrap();
         for fname in ["one.txt", "two.txt"] {
             let p = new.join(fname);
-            wait_for_row_count(&marlin, &p, 1, Duration::from_secs(10));
+            wait_for_row_count(&marlin, &canonicalize_lossy(&p), 1, Duration::from_secs(10));
         }
         watcher.stop().unwrap();
         assert!(


### PR DESCRIPTION
## Summary
- canonicalize paths and strip `\\?\` prefix in `canonicalize_lossy`
- normalize paths in watcher tests when waiting for DB updates

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh`