### PR TITLE
Fix Windows CI toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
+          components: rustfmt, clippy
 
       - name: Check formatting
         run: cargo fmt -- --check

--- a/libmarlin/src/utils.rs
+++ b/libmarlin/src/utils.rs
@@ -77,4 +77,3 @@ pub fn to_db_path<P: AsRef<Path>>(p: P) -> String {
         s.into_owned()
     }
 }
-


### PR DESCRIPTION
## Summary
- add rustfmt and clippy to Windows toolchain
- fix formatting in utils

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `./run_all_tests.sh` *(fails: took too long, manual stop)*