### PR TITLE
Improve watcher test stability

### DIFF
--- a/libmarlin/src/watcher_tests.rs
+++ b/libmarlin/src/watcher_tests.rs
@@ -74,7 +74,7 @@ mod tests {
             )
             .unwrap();
 
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(250));
         let new_file = dir.join("b.txt");
         fs::rename(&file, &new_file).unwrap();
 
@@ -123,7 +123,7 @@ mod tests {
             )
             .unwrap();
 
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(250));
         let new = dir.join("newdir");
         fs::rename(&sub, &new).unwrap();
         let new_canonical = canonicalize_lossy(&new);


### PR DESCRIPTION
## Summary
- allow extra time for the watcher to start before renaming files

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --package libmarlin watcher -- --nocapture`
- `cargo test --workspace --exclude marlin-tui --exclude marlin-cli`